### PR TITLE
Authorize single quote character in address

### DIFF
--- a/helper/regexValidate.js
+++ b/helper/regexValidate.js
@@ -17,7 +17,7 @@ module.exports = function(type) {
 	case "language":
 		return /^en$|^es$|^fr$|^hi$/;
 	case "address":
-		return /^[^!@$^%+={}|<>?"'`;:&]+$/;
+		return /^[^!@$^%+={}|<>?"`;:&]+$/;
 	case "deployment-description":
 		return /^[^@$^%+={}|<>"'`;:&]{3,1024}$/i;
 	case "number":


### PR DESCRIPTION
Fix https://github.com/NikhilM98/sugarizer-school-portal-server/issues/13
Just remove the single character from the regex. Could be interested to escape characters if other issues are raised.